### PR TITLE
implement exporting of only unique entry ids

### DIFF
--- a/src/export_unique_entry_ids.rs
+++ b/src/export_unique_entry_ids.rs
@@ -1,0 +1,30 @@
+use std::fs::{self, File};
+use std::io::Write;
+
+use anyhow::*;
+use crate::{Datamine, EXPORT_DIR, Opt};
+
+pub(crate) fn export_unique_entry_ids(opt: &Opt, datamine: &Datamine) -> Result<()> {
+    fs::create_dir_all(EXPORT_DIR).context("Failed to create export dir")?;
+    let mut file = File::create("export/unique_entry_ids.txt")
+        .context("Failed to create `export/unique_entry_ids.txt`")?;
+
+    let id_prefix = opt.id_prefix.as_deref().unwrap_or("");
+    let id_suffix = opt.id_suffix.as_deref().unwrap_or("");
+    
+    for (sheet_title, sheet) in datamine.iter() {
+        writeln!(file, "{}", sheet_title)?;
+
+        for row in &sheet.rows {
+            let id = match row.get("unique_entry_id") {
+                Some(id) => id,
+                None => continue,
+            };
+            let id = id.as_str().context("Invalid ID format")?;
+
+            writeln!(file, "   {}{}{}", id_prefix, id, id_suffix)?;
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Implements exporting of unique entry IDs for horizonpedia/app_flutter#37

- adds `--only-ids` to export the ids to `export/unique_entry_ids.txt`
- adds `--id-prefix` for adding a prefix to the ids
- adds `--id-suffix` for adding a suffix to the ids